### PR TITLE
fix: issue#30, semanticType runtime error

### DIFF
--- a/packages/frontend/src/queries/featureVis.ts
+++ b/packages/frontend/src/queries/featureVis.ts
@@ -1,5 +1,6 @@
-import { Specification, FieldType } from "visual-insights/src/commonTypes";
+import { Specification } from "visual-insights/src/commonTypes";
 import { geomTypeMap, DataField } from './index';
+import { inferFieldSemanticTypeWithDict, inferFieldTypeWithDict } from "./utils";
 
 export function featureVis(query: Specification, fields: DataField[]) {
   console.log({ query, fields })
@@ -9,12 +10,8 @@ export function featureVis(query: Specification, fields: DataField[]) {
     fieldTypeDict[field.name] = field
   }
 
-  function getFieldSemanticType(field: string): FieldType {
-    return fieldTypeDict[field] ? fieldTypeDict[field].semanticType : "nominal";
-  }
-  function getFieldType(field: string): DataField['type'] {
-    return fieldTypeDict[field] ? fieldTypeDict[field].type : 'dimension'
-  }
+  const getFieldSemanticType = (field: string) => inferFieldSemanticTypeWithDict(field, fieldTypeDict);
+  const getFieldType = (field: string) => inferFieldTypeWithDict(field, fieldTypeDict);
   
   function shouldFieldAggregate(
     field: string,

--- a/packages/frontend/src/queries/targetVis.ts
+++ b/packages/frontend/src/queries/targetVis.ts
@@ -1,5 +1,6 @@
-import { Specification, FieldType } from "visual-insights/src/commonTypes";
+import { Specification } from "visual-insights/src/commonTypes";
 import { geomTypeMap, DataField } from './index';
+import { inferFieldSemanticTypeWithDict, inferFieldTypeWithDict } from './utils';
 
 export function targetVis(query: Specification, fields: DataField[]) {
   let fieldTypeDict: {[key: string]: DataField} = {};
@@ -7,12 +8,8 @@ export function targetVis(query: Specification, fields: DataField[]) {
     fieldTypeDict[field.name] = field
   }
 
-  function getFieldSemanticType(field: string): FieldType {
-    return fieldTypeDict[field].semanticType || "nominal";
-  }
-  function getFieldType(field: string): DataField['type'] {
-    return fieldTypeDict[field].type || 'dimension'
-  }
+  const getFieldSemanticType = (field: string) => inferFieldSemanticTypeWithDict(field, fieldTypeDict);
+  const getFieldType = (field: string) => inferFieldTypeWithDict(field, fieldTypeDict);
   
   function shouldFieldAggregate(
     field: string,

--- a/packages/frontend/src/queries/utils.ts
+++ b/packages/frontend/src/queries/utils.ts
@@ -1,0 +1,12 @@
+import { FieldType } from "visual-insights/src/commonTypes";
+import { DataField } from "./index";
+interface FieldTypeDictonary {
+    [key: string]: DataField
+}
+export function inferFieldSemanticTypeWithDict(field: string, fieldTypeDict: FieldTypeDictonary): FieldType {
+  return fieldTypeDict[field] ? fieldTypeDict[field].semanticType : "nominal";
+}
+
+export function inferFieldTypeWithDict(field: string, fieldTypeDict: FieldTypeDictonary): DataField["type"] {
+  return fieldTypeDict[field] ? fieldTypeDict[field].type : "dimension";
+}


### PR DESCRIPTION
Issues: #30 .

It seems `targetVis` fails to handle the case when the field does not exist, which is possible because the recommended visual specification could provide encodings without color channel.

The same case had been considered in `featureVis`, but forgotten in `targetVis`.

However, normally, data views targetVis get should have at least one dimension(feature). And the auto specification has a high possibility of encoding the feature into color(perception error). (it passes tests with different dataset when developing(kaggle/titanic, kaggle/kelper, etc))

I'm curious about what channel is used for the dimension if it is not color and why(depends on the dataset).
or the dataset might contain no dimension.