### PR TITLE
[bugfix] {DataSource} empty numeric values became 0 and could not be cleaned

### DIFF
--- a/packages/rath-client/src/pages/dataSource/utils/index.ts
+++ b/packages/rath-client/src/pages/dataSource/utils/index.ts
@@ -106,7 +106,7 @@ export async function loadDataFile(props: LoadDataFileProps): Promise<{
             const content = (await readRaw(file, encoding) ?? '');
             const rows = content.split(/\r?\n/g).map(row => row.split(separator));
             const fields = rows[0]?.map<IMuteFieldBase>((h, i) => ({
-                fid: `col_${i}`,
+                fid: `col_${i + 1}`,
                 name: h,
                 geoRole: '?',
                 analyticType: '?',
@@ -137,19 +137,6 @@ export async function loadDataFile(props: LoadDataFileProps): Promise<{
         if (sampleMethod === SampleKey.reservoir) {
             rawData = Sampling.reservoirSampling(rawData, sampleSize)
         }
-    } else if (file.type.startsWith('text/')) {
-        let content = (await readRaw(file, encoding) ?? '');
-        if (separator && separator !== ',') {
-            content = content.replaceAll(
-                new RegExp(`\\\\{0, 2}${separator}`, 'g'),
-                part => `${new RegExp(`^(\\{2})?`).exec(part)?.[0] ?? ''},`,
-            );
-        }
-        const translatedFile = new File([new Blob([content], { type: 'text/plain' })], 'file.csv');
-        rawData = (await KFileReader.csvReader({
-            file: translatedFile,
-            encoding,
-        })) as IRow[];
     } else {
         throw new Error(`unsupported file type=${file.type} `)
     }

--- a/packages/rath-client/src/workers/engine/cleaner.ts
+++ b/packages/rath-client/src/workers/engine/cleaner.ts
@@ -18,6 +18,13 @@ function transformDataTypes (dataSource: IRow[], fields: IRawField[]): IRow[] {
                     record[field.fid] = String(row[field.fid])
                 }
             }
+            if (row[field.fid] === '') {
+                // beware that `Number('')` is `0`
+                if (['quantitative', 'ordinal'].includes(field.semanticType)) {
+                    record[field.fid] = null;
+                }
+                continue;
+            }
             if (field.semanticType === 'quantitative') {
                 record[field.fid] = Transform.transNumber(row[field.fid]);
             } else if (field.semanticType === 'ordinal' && !isNaN(Number(row[field.fid]))) {


### PR DESCRIPTION
In csv-like files, empty values are read as empty strings `""`. Here was a bug that validation check of numeric values (quantitative or ordinal) got bypassed because the values were transformed into `0`s. Prevent using `Number()` to transform an unknown object until you're sure that it is not `""` or `null` because the trap where
```typescript
Number("");          // 0
isNaN(Number(""));   // false
Number(null);        // 0
isNaN(Number(null)); // false
```