### PR TITLE
使用 .env 文件定义服务域名

### DIFF
--- a/packages/rath-client/.env
+++ b/packages/rath-client/.env
@@ -1,0 +1,1 @@
+REACT_APP_PREDICTION_API_SERVICE_HOST="https://kanaries.net"

--- a/packages/rath-client/src/consts/hosts.ts
+++ b/packages/rath-client/src/consts/hosts.ts
@@ -1,0 +1,2 @@
+/**模型预测服务 */
+export const PREDICTION_SERVICE = process.env.REACT_APP_PREDICTION_API_SERVICE_HOST;

--- a/packages/rath-client/src/pages/causal/predict.ts
+++ b/packages/rath-client/src/pages/causal/predict.ts
@@ -1,5 +1,6 @@
 import { notify } from "../../components/error";
 import type { IRow, IFieldMeta } from "../../interfaces";
+import { PREDICTION_SERVICE } from "../../consts/hosts";
 
 
 export const PredictAlgorithms = [
@@ -47,8 +48,8 @@ export interface IPredictResult {
     result: PredictResultItem[];
 }
 
-// TODO: 模型预测服务：上生产环境后改称线上服务地址
-const PredictApiPath = 'http://127.0.0.1:5533/api/train_test';
+/**预测服务地址 */
+const PredictApiPath = `${PREDICTION_SERVICE}/api/train_test`;
 
 export const execPredict = async (props: IPredictProps): Promise<IPredictResult | null> => {
     try {


### PR DESCRIPTION
### 这个 PR 做了什么?
CRA 本身支持使用 `.env` 文件[自定义定义环境变量](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env)

方案概述：
1. 在对应的环境文件中定义 `REACT_APP_PREDICTION_API_SERVICE_HOST`
    - 由于 `.env.local` 不会也不应该被提交到仓库，因此本地开发时入需要，则要在 `rath-client` 目录下手动新增一个 `.env.local` 文件定义本地服务
1. 新增 `src/consts/hosts.ts` 文件，将 `REACT_APP_PREDICTION_API_SERVICE_HOST` 赋值给常量 `PREDICTION_SERVICE`
    - 避免开发者直接使用与编译工具强相关的特性，防止在后续切工具时出现大规模修改的问题
    - 有必要时可直接在定义文件中处理该数据
1. 在调用服务的地方使用常量 `PREDICTION_SERVICE` 拼接完整地址

### 这个 PR 是什么类型?

- [x] 新功能(Feature) [#228 模型预测服务：上生产环境后改称线上服务地址](https://github.com/Kanaries/Rath/issues/228)

### 这个 PR 满足以下需求:
- [ ] 提交到 master 分支
- [x] Commit 信息遵循 Angular Style Commit Message Conventions
- [ ] 所有测试用例已经通过
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

### 其它需要 Reviewer 或社区知晓的内容

`.env` 中的域名使用的是线上体验版的域名

