### PR TITLE
fix(toStream): Ensure that `observe` is torn down when observable is unsubscribed.

### DIFF
--- a/packages/rath-client/src/utils/mobx-utils.ts
+++ b/packages/rath-client/src/utils/mobx-utils.ts
@@ -6,11 +6,9 @@ export function toStream<T>(
     fireImmediately: boolean = false
 ): Observable<T> {
     const computedValue = computed(expression)
-    return new Observable<T>((subscriber) => {
-        observe<T>(computedValue, (props) => {
-            subscriber.next(props.newValue as any)
-        }, fireImmediately)
-    })
+    return new Observable<T>((subscriber) => observe<T>(computedValue, (props) => {
+        subscriber.next(props.newValue as any)
+    }, fireImmediately))
 }
 export class StreamListener<T> {
     public current: T


### PR DESCRIPTION
Resolves an issue where the `disposer` from MobX was not captured and returned in the `Observable` constructor, and therefor it will never tear down.