### PR TITLE
fix(profilingView): get a wrong fid when appending a set filter

### DIFF
--- a/packages/rath-client/src/components/fieldFilter/index.tsx
+++ b/packages/rath-client/src/components/fieldFilter/index.tsx
@@ -25,15 +25,26 @@ const FieldFilter: React.FC<FieldFilterProps> = props => {
 
     const { rawDataStorage, rawDataMetaInfo } = dataSourceStore;
 
-    const [filter, setFilter] = useState<IFilter>((meta && meta.semanticType === 'quantitative') ? {
-        fid,
-        type: 'range',
-        range: [0, 0],
-    } : {
-        fid,
-        type: 'set',
-        values: []
-    })
+    const getInitFilter = useCallback((): IFilter => {
+        if (meta?.semanticType === 'quantitative') {
+            return {
+                fid,
+                type: 'range',
+                range: [0, 0],
+            };
+        }
+        return {
+            fid,
+            type: 'set',
+            values: [],
+        };
+    }, [fid, meta?.semanticType]);
+
+    const [filter, setFilter] = useState<IFilter>(getInitFilter);
+
+    useEffect(() => {
+        setFilter(getInitFilter);
+    }, [getInitFilter]);
 
     const [fieldRange, setFieldRange] = useState<[number, number]>([0, 0])
     const filterType = filter.type;


### PR DESCRIPTION
Issue description: When appending a filter in the profiling view (Statistics), change to a new field, the filter will also be applied to the first field. It will propably makes the data empty.

Troubleshooting: There's only one filter component instance, and it's reusing the `fid` to constructor a new filter everytime but it'd never changed after mounted.
