### PR TITLE
Fix clickhouse_getresult method

### DIFF
--- a/services/connector/bp/basefunc.py
+++ b/services/connector/bp/basefunc.py
@@ -217,7 +217,7 @@ class basefunc:
         return [meta, res_list[0], res_list[1]]
 
     @staticmethod
-    def clickhouse_getresult(sql, uri=None, engine=None):
+    def clickhouse_getresult(sql, uri=None, engine=None,**kwargs):
         if engine is None:
             engine = create_engine(uri, echo=True)
         res = engine.execute(sql)


### PR DESCRIPTION
Fixing error message when using Clickhouse datasource.
```
  File "/connector/bp/bp_database.py", line 77, in invoke
    res_list = dict_func['{0}_getresult'.format(source_type)].__func__(uri=uri, sql=sql,
TypeError: basefunc.clickhouse_getresult() got an unexpected keyword argument 'credentials'
```