### PR TITLE
fixed: webpack5 worker loader

### DIFF
--- a/packages/rath-client/src/dev/services.ts
+++ b/packages/rath-client/src/dev/services.ts
@@ -4,7 +4,7 @@ import { workerService } from '../services';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import ExpandDateTimeWorker from './workers/dateTimeExpand.worker.js?worker';
+// import ExpandDateTimeWorker from './workers/dateTimeExpand.worker.js?worker';
 import { dateTimeExpand, doTest } from './workers/engine/dateTimeExpand';
 import { checkExpandEnv } from './workers/engine/checkExpandEnv';
 
@@ -25,7 +25,7 @@ export async function expandDateTimeService(props: ExpandDateTimeProps): Promise
         return res;
     } else {
         try {
-            const worker = new ExpandDateTimeWorker();
+            const worker = new Worker(new URL('./workers/dateTimeExpand.worker.js', import.meta.url));
             const result = await workerService<ExpandDateTimeProps, ExpandDateTimeProps>(worker, props);
             worker.terminate();
             if (result.success) {

--- a/packages/rath-client/src/pages/causal/discoveryService.ts
+++ b/packages/rath-client/src/pages/causal/discoveryService.ts
@@ -3,7 +3,7 @@ import type { CausalDiscoveryRequest, CausalDiscoveryResult } from './discoveryT
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import CausalDiscoveryWorker from './discovery.worker.ts?worker';
+// import CausalDiscoveryWorker from './discovery.worker.ts?worker';
 
 function normalizeCellValue(value: unknown): unknown {
     if (
@@ -65,7 +65,7 @@ function createSerializableRequest(props: CausalDiscoveryRequest): CausalDiscove
 }
 
 export async function causalDiscoveryService(props: CausalDiscoveryRequest): Promise<CausalDiscoveryResult> {
-    const worker = new CausalDiscoveryWorker();
+    const worker = new Worker(new URL('./discovery.worker.ts', import.meta.url));
     try {
         const payload = createSerializableRequest(props);
         const result = await workerService<CausalDiscoveryResult, CausalDiscoveryRequest>(worker, payload);

--- a/packages/rath-client/src/pages/causal/service.ts
+++ b/packages/rath-client/src/pages/causal/service.ts
@@ -4,7 +4,7 @@ import { workerService } from '../../services';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import CausalComputationWorker from './computation.worker.js?worker';
+// import CausalComputationWorker from './computation.worker.js?worker';
 
 type ICausalProps = {
     task: 'ig';
@@ -19,7 +19,7 @@ type ICausalProps = {
 
 export async function causalService(props: ICausalProps): Promise<number[][]> {
     try {
-        const worker = new CausalComputationWorker();
+        const worker = new Worker(new URL('./computation.worker.js', import.meta.url));
         const result = await workerService<number[][], ICausalProps>(worker, props);
         worker.terminate();
         if (result.success) {

--- a/packages/rath-client/src/pages/dataSource/utils/index.ts
+++ b/packages/rath-client/src/pages/dataSource/utils/index.ts
@@ -13,7 +13,7 @@ import { workerService } from "../../../services/index";
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import FileDataTransformWorker from './transFileData.worker?worker';
+// import FileDataTransformWorker from './transFileData.worker?worker';
 
 export enum SampleKey {
   none = 'none',
@@ -42,7 +42,7 @@ export async function rawData2DataWithBaseMetas (rawData: IRow[]): Promise<{
     fields: IMuteFieldBase[];
     dataSource: IRow[]
 }> {
-    const worker = new FileDataTransformWorker()
+    const worker = new Worker(new URL('./transFileData.worker', import.meta.url))
     const res = await workerService<{
             fields: IMuteFieldBase[];
             dataSource: IRow[]

--- a/packages/rath-client/src/services/base.ts
+++ b/packages/rath-client/src/services/base.ts
@@ -1,27 +1,27 @@
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import RathEngineWorker from '../workers/engine/index.worker?worker';
+// import RathEngineWorker from '../workers/engine/index.worker?worker';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import InferMetaWorker from '../workers/metaInfer.worker?worker';
+// import InferMetaWorker from '../workers/metaInfer.worker?worker';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import LoaWorker from '../workers/loa/index.worker?worker';
+// import LoaWorker from '../workers/loa/index.worker?worker';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import CleanWorker from '../workers/clean.worker?worker';
+// import CleanWorker from '../workers/clean.worker?worker';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import FilterWorker from '../workers/filterData.worker?worker';
+// import FilterWorker from '../workers/filterData.worker?worker';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import LabDistVisWorker from '../workers/labDistVis.worker?worker';
+// import LabDistVisWorker from '../workers/labDistVis.worker?worker';
 
 import { MessageProps } from '../workers/engine/service';
 
@@ -83,7 +83,7 @@ export function initRathWorker(engineMode: string) {
         // } else {
         //   rathGlobalWorkerRef.current = new RathEngineWorker();
         // }
-        rathGlobalWorkerRef.current = new RathEngineWorker();
+        rathGlobalWorkerRef.current = new Worker(new URL('../workers/engine/index.worker', import.meta.url));
     }
 }
 
@@ -104,7 +104,7 @@ export interface InferMetaServiceProps {
 export async function inferMetaService(props: InferMetaServiceProps): Promise<IRawField[]> {
     let metas: IRawField[] = [];
     try {
-        const worker = new InferMetaWorker();
+        const worker = new Worker(new URL('../workers/metaInfer.worker', import.meta.url));
         const result = await workerService<IRawField[], InferMetaServiceProps>(worker, props);
         if (result.success) {
             metas = result.data;
@@ -132,7 +132,7 @@ export type CleanServiceProps = {
 export async function cleanDataService(props: CleanServiceProps): Promise<IRow[]> {
     let data: IRow[] = [];
     try {
-        const worker = new CleanWorker();
+        const worker = new Worker(new URL('../workers/clean.worker', import.meta.url));
         const result = await workerService<IRow[], CleanServiceProps>(worker, props);
         if (result.success) {
             data = result.data;
@@ -169,7 +169,7 @@ export async function filterDataService(props: FilterServiceProps): Promise<{row
         versionCode: -1
     };
     try {
-        const worker = new FilterWorker();
+        const worker = new Worker(new URL('../workers/filterData.worker', import.meta.url));
         const result = await workerService<{rows: IRow[]; versionCode: number}, FilterServiceProps>(worker, props);
         if (result.success) {
             data = result.data;
@@ -255,7 +255,7 @@ export async function loaEngineService<R = any>(
                 throw new Error(`[result.fail] ${result.message}`);
             }
         } else {
-            const worker = new LoaWorker();
+            const worker = new Worker(new URL('../workers/loa/index.worker', import.meta.url));
             const result = await workerService<R, ILoaProps>(worker, props);
             worker.terminate();
             if (result.success) {
@@ -285,7 +285,7 @@ export async function labDistVisService<
 >(props: P): Promise<R> {
     let data: R;
     try {
-        const worker = new LabDistVisWorker();
+        const worker = new Worker(new URL('../workers/labDistVis.worker', import.meta.url));
         const result = await workerService<R, P>(worker, props);
         if (result.success) {
             data = result.data;

--- a/packages/rath-client/src/services/meta.ts
+++ b/packages/rath-client/src/services/meta.ts
@@ -2,7 +2,7 @@ import { IRow } from 'visual-insights';
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
 // eslint-disable-next-line
-import fieldMetaWorker from '../workers/fieldMeta.worker?worker';
+// import fieldMetaWorker from '../workers/fieldMeta.worker?worker';
 import { IFieldMeta, IRawField } from '../interfaces';
 import { workerService } from './base';
 
@@ -13,7 +13,7 @@ export interface ComputeFieldMetaServiceProps {
 export async function computeFieldMetaService(props: ComputeFieldMetaServiceProps): Promise<IFieldMeta[]> {
     let metas: IFieldMeta[] = [];
     try {
-        const worker = new fieldMetaWorker();
+        const worker = new Worker(new URL('../workers/fieldMeta.worker.js', import.meta.url));
         const result = await workerService<IFieldMeta[], ComputeFieldMetaServiceProps>(worker, props);
         if (result.success) {
             metas = result.data;

--- a/packages/rath-client/src/services/r-insight.ts
+++ b/packages/rath-client/src/services/r-insight.ts
@@ -1,6 +1,6 @@
 /* eslint import/no-webpack-loader-syntax:0 */
 // @ts-ignore
-import RInsightWorker from '../workers/insight/r-insight.worker?worker';
+// import RInsightWorker from '../workers/insight/r-insight.worker?worker';
 import type { IRInsightExplainProps, IRInsightExplainResult } from '../workers/insight/r-insight.worker';
 import { getGlobalStore } from '../store';
 import { workerService } from './base';
@@ -25,7 +25,7 @@ export const RInsightService = async (props: IRInsightExplainProps, mode: 'worke
             throw new Error('[RInsight server]' + result.message);
         }
     }
-    const worker = new RInsightWorker();
+    const worker = new Worker(new URL('../workers/insight/r-insight.worker.ts', import.meta.url));
     const result = await workerService<IRInsightExplainResult, IRInsightExplainProps>(worker, props);
     worker.terminate();
     if (result.success) {


### PR DESCRIPTION
This is a PR made by @Shirllyuan internally, but havn't tested on win devices.

+ Operating Platform: Windows 10 Professional 21H1 64-bit operating system, x64-based processor
+ Processor: Intel(R) Core(TM) i5-9300H CPU @ 2.40GHz 2.40 GHz
+ Runtime Environment: Nodejs v16.10.0

After running "yarn workspace rath-client start", the above error occurs.

## solutions
Determined to be a web worker loading issue, the current webpack version is:
```bash
webpack: ^5.64.4
```

According to the official documentation, in webpack 5, another method has replaced the worker-loader loading method, which caused this problem.
The main modification method is as follows:
Change the current worker loading method, as shown in the following image:
![image](https://github.com/Kanaries/Rath/assets/22167673/94f4862e-2dc4-46ad-8d79-7e6602399f46)

changed to 

![image](https://github.com/Kanaries/Rath/assets/22167673/268bf304-612c-415b-88dc-e861a5e667c8)

config of worker loader can be deleted:
![image](https://github.com/Kanaries/Rath/assets/22167673/a02b4494-1336-4da2-beae-7f5629b5b218)



