### PR TITLE
fix: data crash when import data

### DIFF
--- a/packages/rath-client/src/pages/dataSource/dataTable/index.tsx
+++ b/packages/rath-client/src/pages/dataSource/dataTable/index.tsx
@@ -48,7 +48,7 @@ const ADD_BATCH_SIZE = 5;
 
 const DataTable: React.FC = (props) => {
     const { dataSourceStore } = useGlobalStore();
-    const { filteredDataMetaInfo, fieldsWithExtSug: fields, filteredDataStorage } = dataSourceStore;
+    const { filteredDataMetaInfo, fieldsWithExtSug: fields, filteredDataStorage, datasetId } = dataSourceStore;
     const [filteredData, setFilteredData] = useState<IRow[]>([]);
     const [textSelectList, setTextSelectList] = useState<IFieldTextSelection[]>([]);
     const [editTP, setEditTP] = useState<boolean>(false);
@@ -68,6 +68,23 @@ const DataTable: React.FC = (props) => {
         specific: 1,
         nlp: 1,
     });
+    useEffect(() => {
+        // clean state
+        setFilteredData([]);
+        setTextSelectList([]);
+        setEditTP(false);
+        setGroupedTextPatternList(initGroupedTextPatternList());
+        setTpPos({
+            groupKey: 'knowledge',
+            index: 0,
+        });
+        setGroupShownSize({
+            knowledge: 1,
+            generalize: 1,
+            specific: 1,
+            nlp: 1,
+        });
+    }, [datasetId]);
 
     const tsList2tpList = useCallback((tsl: IFieldTextSelection[]) => {
         try {

--- a/packages/rath-client/src/store/dataSourceStore.ts
+++ b/packages/rath-client/src/store/dataSourceStore.ts
@@ -515,6 +515,7 @@ export class DataSourceStore {
     public async loadDataWithInferMetas (dataSource: IRow[], fields: IMuteFieldBase[], tag?: DataSourceTag | undefined) {
         if (fields.length > 0 && dataSource.length > 0) {
             const metas = await inferMetaService({ dataSource, fields })
+            this.initStore()
             // vega-lite's title contains \n will fail to render
             // fix: https://github.com/Kanaries/Rath/issues/381
             metas.forEach(m => {


### PR DESCRIPTION
clean all store when importing data, to resolve the bug when importing data.
reproduce:
1. select a datasource.
2. add some filters in datasource.
3. click import data button, and select a new datasource.