### PR TITLE
Security: SQL injection in table/view metadata query construction

### DIFF
--- a/packages/olap-connector/app/services/chmeta.ts
+++ b/packages/olap-connector/app/services/chmeta.ts
@@ -16,6 +16,9 @@ export async function CHQuery (sql: string): Promise<string> {
 }
 
 export async function getFieldMetas(viewName: string): Promise<IDBFieldMeta[]> {
+    if (!/^[A-Za-z0-9_]+$/.test(viewName)) {
+        throw new Error('Invalid view name');
+    }
     const metaRaw = await CHQuery(`DESC ${viewName}`);
     return metaRaw.slice(0, -1).split('\n').map(fr => {
         const infos = fr.split('\t');


### PR DESCRIPTION
## Problem

`getFieldMetas` builds `DESC ${viewName}` using string interpolation. A crafted `viewName` can inject additional SQL tokens/statements depending on backend parsing rules.

**Severity**: `high`
**File**: `packages/olap-connector/app/services/chmeta.ts`

## Solution

Treat `viewName` as untrusted. Validate against a strict identifier regex (e.g., `^[A-Za-z0-9_]+$`), reject anything else, and if possible resolve from server-maintained metadata rather than direct user input.

## Changes

- `packages/olap-connector/app/services/chmeta.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
